### PR TITLE
Int issues in genotype calculations

### DIFF
--- a/moments/LD/genotype_calculations.pyx
+++ b/moments/LD/genotype_calculations.pyx
@@ -24,7 +24,7 @@ cpdef compute_D(np.ndarray[np.int32_t, ndim=2] Counts):
     cdef np.ndarray[np.int32_t, ndim=1] n7 = Counts[:,6]
     cdef np.ndarray[np.int32_t, ndim=1] n8 = Counts[:,7]
     cdef np.ndarray[np.int32_t, ndim=1] n9 = Counts[:,8]
-    cdef np.ndarray[np.int32_t, ndim=1] n
+    cdef np.ndarray[np.int64_t, ndim=1] n
     n = np.sum(Counts, axis=1)
     cdef np.ndarray[np.float_t, ndim=1] numer
     cdef np.ndarray[np.float_t, ndim=1] denom
@@ -51,7 +51,7 @@ cpdef compute_D2(np.ndarray[np.int32_t, ndim=2] Counts):
     cdef np.ndarray[np.int32_t, ndim=1] n7 = Counts[:,6]
     cdef np.ndarray[np.int32_t, ndim=1] n8 = Counts[:,7]
     cdef np.ndarray[np.int32_t, ndim=1] n9 = Counts[:,8]
-    cdef np.ndarray[np.int32_t, ndim=1] n
+    cdef np.ndarray[np.int64_t, ndim=1] n
     n = np.sum(Counts, axis=1)
     cdef np.ndarray[np.float_t, ndim=1] numer
     cdef np.ndarray[np.float_t, ndim=1] denom
@@ -78,7 +78,7 @@ cpdef compute_Dz(np.ndarray[np.int32_t, ndim=2] Counts):
     cdef np.ndarray[np.int32_t, ndim=1] n7 = Counts[:,6]
     cdef np.ndarray[np.int32_t, ndim=1] n8 = Counts[:,7]
     cdef np.ndarray[np.int32_t, ndim=1] n9 = Counts[:,8]
-    cdef np.ndarray[np.int32_t, ndim=1] n
+    cdef np.ndarray[np.int64_t, ndim=1] n
     n = np.sum(Counts, axis=1)
     cdef np.ndarray[np.float_t, ndim=1] numer
     cdef np.ndarray[np.float_t, ndim=1] denom
@@ -105,7 +105,7 @@ cpdef compute_pi2(np.ndarray[np.int32_t, ndim=2] Counts):
     cdef np.ndarray[np.int32_t, ndim=1] n7 = Counts[:,6]
     cdef np.ndarray[np.int32_t, ndim=1] n8 = Counts[:,7]
     cdef np.ndarray[np.int32_t, ndim=1] n9 = Counts[:,8]
-    cdef np.ndarray[np.int32_t, ndim=1] n
+    cdef np.ndarray[np.int64_t, ndim=1] n
     n = np.sum(Counts, axis=1)
     cdef np.ndarray[np.float_t, ndim=1] numer
     cdef np.ndarray[np.float_t, ndim=1] denom


### PR DESCRIPTION
Tests in the workflow are failing with the error `ValueError: Buffer dtype mismatch, expected 'int32_t' but got 'long'`.

See related issue here: https://bitbucket.org/simongravel/moments/issues/109/valueerror-buffer-dtype-mismatch-in

This suggests there could be an issue with the default int type on Mac vs Linux (?), so we need to test this both on Linux and Mac OS.