### PR TITLE
Allow time-dependent selection functions

### DIFF
--- a/moments/Spectrum_mod.py
+++ b/moments/Spectrum_mod.py
@@ -703,8 +703,10 @@ class Spectrum(np.ma.masked_array):
         :param dt_fac: The timestep factor, default is 0.02. This parameter typically
             does not need to be adjusted.
         :type dt_fac: float, optional
-        :param gamma: The selection coefficient (:math:`2 N_e s`), or list of selection
-            coefficients if more than one population.
+        :param gamma: The selection coefficient (:math:`2 N_e s`), or a list of
+            selection coefficients that may differ across populations. In this case,
+            one value must be provided for each population, so the vector must have
+            length equal to the number of populations.
         :type gamma: float or list of floats, optional
         :param h: The dominance coefficient, or list of dominance coefficients in
             each population, if more than one population.
@@ -815,11 +817,11 @@ class Spectrum(np.ma.masked_array):
         else:
             if gamma is None:
                 gamma = np.zeros(len(n))
-            elif not hasattr(gamma, "__len__"):
+            elif not hasattr(gamma, "__len__") and not callable(gamma):
                 gamma = gamma * np.ones(len(n))
             if h is None:
                 h = 0.5 * np.ones(len(n))
-            elif not hasattr(h, "__len__"):
+            elif not hasattr(h, "__len__") and not callable(h):
                 h = h * np.ones(len(n))
             if m is None:
                 m = np.zeros([len(n), len(n)])

--- a/tests/test_Results.py
+++ b/tests/test_Results.py
@@ -105,6 +105,284 @@ class IntegrationValidityTestCase(unittest.TestCase):
             fs.integrate(nu_func, 1)
 
 
+class TimeDependentSelection(unittest.TestCase):
+    def setUp(self):
+        self.startTime = time.time()
+
+    def tearDown(self):
+        t = time.time() - self.startTime
+        print("%s: %.3f seconds" % (self.id(), t))
+
+    def test_single_population_constant_selection(self):
+        n = 20
+        gamma = -2
+        # given as single value
+        fs = moments.Spectrum(moments.LinearSystem_1D.steady_state_1D(n, gamma=gamma))
+        fs.integrate([1], 0.3, gamma=gamma)
+
+        # given as an array
+        fs2 = moments.Spectrum(moments.LinearSystem_1D.steady_state_1D(n, gamma=gamma))
+        fs2.integrate([1], 0.3, gamma=[gamma])
+        self.assertTrue(np.allclose(fs, fs2))
+
+        # given as a function
+        fs2 = moments.Spectrum(moments.LinearSystem_1D.steady_state_1D(n, gamma=gamma))
+        gamma_func = lambda t: gamma
+        fs2.integrate([1], 0.3, gamma=gamma_func)
+        self.assertTrue(np.allclose(fs, fs2))
+
+        fs2 = moments.Spectrum(moments.LinearSystem_1D.steady_state_1D(n, gamma=gamma))
+        gamma_func = lambda t: [gamma]
+        fs2.integrate([1], 0.3, gamma=gamma_func)
+        self.assertTrue(np.allclose(fs, fs2))
+
+        # h also given, then as a function
+        fs2 = moments.Spectrum(moments.LinearSystem_1D.steady_state_1D(n, gamma=gamma))
+        gamma_func = lambda t: gamma
+        h_func = lambda t: 0.5
+        fs2.integrate([1], 0.3, gamma=gamma_func)
+        self.assertTrue(np.allclose(fs, fs2))
+
+        fs2 = moments.Spectrum(moments.LinearSystem_1D.steady_state_1D(n, gamma=gamma))
+        gamma_func = lambda t: gamma
+        h_func = lambda t: [0.5]
+        fs2.integrate([1], 0.3, gamma=gamma_func)
+        self.assertTrue(np.allclose(fs, fs2))
+
+    def test_single_population_pw_constant_selection(self):
+        n = 20
+        gamma1 = -2
+        T1 = 0.2
+        nu1 = 2
+        gamma2 = -5
+        T2 = 0.3
+        nu2 = 0.5
+        # given as single value
+        fs = moments.Spectrum(moments.LinearSystem_1D.steady_state_1D(n))
+        fs.integrate([nu1], T1, gamma=gamma1, dt_fac=0.005)
+        fs.integrate([nu2], T2, gamma=gamma2, dt_fac=0.005)
+
+        gamma_func = lambda t: gamma1 if t < T1 else gamma2
+        nu_func = lambda t: [nu1] if t < T1 else [nu2]
+        fs2 = moments.Spectrum(moments.LinearSystem_1D.steady_state_1D(n))
+        fs2.integrate(nu_func, T1 + T2, gamma=gamma_func, dt_fac=0.005)
+
+        self.assertTrue(np.allclose(fs, fs2))
+
+        # vary h as well
+        h1 = 0.2
+        h2 = 0.8
+        h_func = lambda t: h1 if t < T1 else h2
+
+        fs = moments.Spectrum(moments.LinearSystem_1D.steady_state_1D(n))
+        fs.integrate([nu1], T1, gamma=gamma1, h=h1, dt_fac=0.005)
+        fs.integrate([nu2], T2, gamma=gamma2, h=h2, dt_fac=0.005)
+        fs2 = moments.Spectrum(moments.LinearSystem_1D.steady_state_1D(n))
+        fs2.integrate(nu_func, T1 + T2, gamma=gamma_func, h=h_func, dt_fac=0.005)
+
+        self.assertTrue(np.allclose(fs, fs2))
+
+    def test_single_population_nonconstant(self):
+        n = 30
+        T = 0.5
+        gamma0 = -5
+        gamma_func = lambda t: gamma0 * np.exp(-t / T)
+
+        fs = moments.Spectrum(moments.LinearSystem_1D.steady_state_1D(n, gamma=gamma0))
+        fs.integrate([1], T, gamma=gamma_func)
+
+    def test_two_pop_nomig_constant_equal(self):
+        n = 20
+        T = 0.3
+        gamma = -3
+
+        fs = moments.Spectrum(
+            moments.LinearSystem_1D.steady_state_1D(2 * n, gamma=gamma)
+        )
+        fs = fs.split(0, n, n)
+        fs.integrate([1, 1], T, gamma=gamma)
+
+        fs2 = moments.Spectrum(
+            moments.LinearSystem_1D.steady_state_1D(2 * n, gamma=gamma)
+        )
+        fs2 = fs2.split(0, n, n)
+        gamma_func = lambda t: gamma
+        fs2.integrate([1, 1], T, gamma=gamma_func)
+        self.assertTrue(np.allclose(fs, fs2))
+
+        fs2 = moments.Spectrum(
+            moments.LinearSystem_1D.steady_state_1D(2 * n, gamma=gamma)
+        )
+        fs2 = fs2.split(0, n, n)
+        gamma_func = lambda t: [gamma, gamma]
+        fs2.integrate([1, 1], T, gamma=gamma_func)
+        self.assertTrue(np.allclose(fs, fs2))
+
+        fs2 = moments.Spectrum(
+            moments.LinearSystem_1D.steady_state_1D(2 * n, gamma=gamma)
+        )
+        fs2 = fs2.split(0, n, n)
+        gamma_func = lambda t: [gamma, gamma]
+        h_func = lambda t: 0.5
+        fs2.integrate([1, 1], T, gamma=gamma_func, h=h_func)
+        self.assertTrue(np.allclose(fs, fs2))
+
+        fs2 = moments.Spectrum(
+            moments.LinearSystem_1D.steady_state_1D(2 * n, gamma=gamma)
+        )
+        fs2 = fs2.split(0, n, n)
+        gamma_func = lambda t: [gamma, gamma]
+        h_func = lambda t: [0.5, 0.5]
+        fs2.integrate([1, 1], T, gamma=gamma_func, h=h_func)
+        self.assertTrue(np.allclose(fs, fs2))
+
+    def test_two_pop_nomig_constant_unequal(self):
+        n = 20
+        T = 0.3
+        gamma0 = -3
+        gamma1 = 2
+        gamma2 = 0.1
+        h = 0.1
+        h1 = 0.4
+        h2 = 1.1
+
+        fs = moments.Spectrum(
+            moments.LinearSystem_1D.steady_state_1D(2 * n, gamma=gamma0, h=h)
+        )
+        fs = fs.split(0, n, n)
+        fs.integrate([1, 1], T, gamma=[gamma1, gamma2], h=[h1, h2])
+
+        fs2 = moments.Spectrum(
+            moments.LinearSystem_1D.steady_state_1D(2 * n, gamma=gamma0, h=h)
+        )
+        fs2 = fs2.split(0, n, n)
+        gamma_func = lambda t: [gamma1, gamma2]
+        fs2.integrate([1, 1], T, gamma=gamma_func, h=[h1, h2])
+        self.assertTrue(np.allclose(fs, fs2))
+
+        fs2 = moments.Spectrum(
+            moments.LinearSystem_1D.steady_state_1D(2 * n, gamma=gamma0, h=h)
+        )
+        fs2 = fs2.split(0, n, n)
+        gamma_func = lambda t: [gamma1, gamma2]
+        h_func = lambda t: [h1, h2]
+        fs2.integrate([1, 1], T, gamma=gamma_func, h=h_func)
+        self.assertTrue(np.allclose(fs, fs2))
+
+    def test_two_pop_nomig_pwconstant(self):
+        n = 20
+
+        fs = moments.Spectrum(moments.LinearSystem_1D.steady_state_1D(2 * n, gamma=1))
+        fs = fs.split(0, n, n)
+        fs.integrate([1, 1], 0.1, gamma=[-1, 2], dt_fac=0.005)
+        fs.integrate([1, 1], 0.1, gamma=[-2, 2], dt_fac=0.005)
+        fs.integrate([1, 1], 0.1, gamma=[-2, 1], dt_fac=0.005)
+
+        gamma_func = lambda t: [-1, 2] if t < 0.1 else [-2, 2] if t < 0.2 else [-2, 1]
+        fs2 = moments.Spectrum(moments.LinearSystem_1D.steady_state_1D(2 * n, gamma=1))
+        fs2 = fs2.split(0, n, n)
+        fs2.integrate([1, 1], 0.3, gamma=gamma_func, dt_fac=0.005)
+
+        self.assertTrue(np.allclose(fs, fs2, rtol=0.002))
+
+    def test_two_pop_mig_constant_equal(self):
+        n = 20
+        T = 0.3
+        gamma = -3
+        m = [[0, 2], [1, 0]]
+
+        fs = moments.Spectrum(
+            moments.LinearSystem_1D.steady_state_1D(2 * n, gamma=gamma)
+        )
+        fs = fs.split(0, n, n)
+        fs.integrate([1, 1], T, gamma=gamma, m=m)
+
+        fs2 = moments.Spectrum(
+            moments.LinearSystem_1D.steady_state_1D(2 * n, gamma=gamma)
+        )
+        fs2 = fs2.split(0, n, n)
+        gamma_func = lambda t: gamma
+        fs2.integrate([1, 1], T, gamma=gamma_func, m=m)
+        self.assertTrue(np.allclose(fs, fs2))
+
+        fs2 = moments.Spectrum(
+            moments.LinearSystem_1D.steady_state_1D(2 * n, gamma=gamma)
+        )
+        fs2 = fs2.split(0, n, n)
+        gamma_func = lambda t: [gamma, gamma]
+        fs2.integrate([1, 1], T, gamma=gamma_func, m=m)
+        self.assertTrue(np.allclose(fs, fs2))
+
+        fs2 = moments.Spectrum(
+            moments.LinearSystem_1D.steady_state_1D(2 * n, gamma=gamma)
+        )
+        fs2 = fs2.split(0, n, n)
+        gamma_func = lambda t: [gamma, gamma]
+        h_func = lambda t: 0.5
+        fs2.integrate([1, 1], T, gamma=gamma_func, h=h_func, m=m)
+        self.assertTrue(np.allclose(fs, fs2))
+
+        fs2 = moments.Spectrum(
+            moments.LinearSystem_1D.steady_state_1D(2 * n, gamma=gamma)
+        )
+        fs2 = fs2.split(0, n, n)
+        gamma_func = lambda t: [gamma, gamma]
+        h_func = lambda t: [0.5, 0.5]
+        fs2.integrate([1, 1], T, gamma=gamma_func, h=h_func, m=m)
+        self.assertTrue(np.allclose(fs, fs2))
+
+    def test_two_pop_mig_constant_unequal(self):
+        n = 20
+        T = 0.3
+        gamma0 = -3
+        gamma1 = 2
+        gamma2 = 0.1
+        h = 0.1
+        h1 = 0.4
+        h2 = 1.1
+        m = [[0, 2], [1, 0]]
+
+        fs = moments.Spectrum(
+            moments.LinearSystem_1D.steady_state_1D(2 * n, gamma=gamma0, h=h)
+        )
+        fs = fs.split(0, n, n)
+        fs.integrate([1, 1], T, gamma=[gamma1, gamma2], h=[h1, h2], m=m)
+
+        fs2 = moments.Spectrum(
+            moments.LinearSystem_1D.steady_state_1D(2 * n, gamma=gamma0, h=h)
+        )
+        fs2 = fs2.split(0, n, n)
+        gamma_func = lambda t: [gamma1, gamma2]
+        fs2.integrate([1, 1], T, gamma=gamma_func, h=[h1, h2], m=m)
+        self.assertTrue(np.allclose(fs, fs2))
+
+        fs2 = moments.Spectrum(
+            moments.LinearSystem_1D.steady_state_1D(2 * n, gamma=gamma0, h=h)
+        )
+        fs2 = fs2.split(0, n, n)
+        gamma_func = lambda t: [gamma1, gamma2]
+        h_func = lambda t: [h1, h2]
+        fs2.integrate([1, 1], T, gamma=gamma_func, h=h_func, m=m)
+        self.assertTrue(np.allclose(fs, fs2))
+
+    def test_two_pop_mig_pwconstant(self):
+        n = 20
+        m = [[0, 2], [1, 0]]
+
+        fs = moments.Spectrum(moments.LinearSystem_1D.steady_state_1D(2 * n, gamma=1))
+        fs = fs.split(0, n, n)
+        fs.integrate([1, 1], 0.1, gamma=[-1, 2], m=m, dt_fac=0.005)
+        fs.integrate([1, 1], 0.1, gamma=[-2, 2], m=m, dt_fac=0.005)
+        fs.integrate([1, 1], 0.1, gamma=[-2, 1], m=m, dt_fac=0.005)
+
+        gamma_func = lambda t: [-1, 2] if t < 0.1 else [-2, 2] if t < 0.2 else [-2, 1]
+        fs2 = moments.Spectrum(moments.LinearSystem_1D.steady_state_1D(2 * n, gamma=1))
+        fs2 = fs2.split(0, n, n)
+        fs2.integrate([1, 1], 0.3, gamma=gamma_func, m=m, dt_fac=0.005)
+
+        self.assertTrue(np.allclose(fs, fs2, rtol=0.002))
+
+
 suite = unittest.TestLoader().loadTestsFromTestCase(ResultsTestCase)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Currently, relative sizes and the migration matrix can be given as time-dependent functions. This allows selection and dominance coefficients to also be provided as time-dependent functions. Results have been tested in the one and two population case, both with and without selection for the latter.

Note: code is repeated across `Integration.integrate_nD()` and `Integration_nomig/integrate_nomig()`, to handle the different data types that can be passed to `fs.integrate()`. In a separate PR, these should be written as their own function that can be used by each integration routine. There are other blocks of code within those two functions that should also be made more "modular".