### PR TITLE
Bump to version 1.1.17

### DIFF
--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -61,6 +61,12 @@ If you use ``moments.TwoLocus`` in your research, please cite:
 Change log
 **********
 
+1.1.17
+======
+
+- Allow selection and dominance to be specified as time-dependent functions
+  in SFS integration.
+
 1.1.16
 ======
 

--- a/moments/_version.py
+++ b/moments/_version.py
@@ -1,4 +1,4 @@
 """Version information."""
 
 # The following line *must* be the last in the module, exactly as formatted:
-__version__ = "1.1.16"
+__version__ = "1.1.17"


### PR DESCRIPTION
This version includes updates to docstrings in the Integration and Numerics functions for SFS integration and manipulations. We also now allow `gamma` and `h` to be passed as time-dependent functions, so that selection can change over time during integration. This should also merge to the workflow to build the docs in github pages.