### PR TITLE
LD integration with dt_fac and add H2 functionality

### DIFF
--- a/moments/Demes/Inference.py
+++ b/moments/Demes/Inference.py
@@ -3,7 +3,7 @@
 # specifies parameters to be fit that align with the input YAML demography.
 
 import demes
-import ruamel
+import ruamel.yaml
 import moments
 import numpy as np
 import scipy.optimize
@@ -30,9 +30,23 @@ def _get_params_dict(fname):
     Options:
     - parameters (what to fit)
     - constraints
+    Below note is from the demes load_dump.py file, re: YAML support in python.
     """
-    with open(fname, "r") as fin:
-        options = ruamel.yaml.load(fin, Loader=ruamel.yaml.Loader)
+    # NOTE: The state of Python YAML libraries in 2020 leaves much to be desired.
+    # The pyyaml library supports only YAML v1.1, which has some awkward corner
+    # cases that have been fixed in YAML v1.2. A fork of pyaml, ruamel.yaml,
+    # does support YAML v1.2, and introduces a new API for parsing/emitting
+    # with additional features and desirable behaviour.
+    # However, neither pyyaml nor ruamel guarantee API stability, and neither
+    # provide complete reference documentation for their APIs.
+    # The YAML code in demes is limited to the following two functions,
+    # which are hopefully simple enough to not suffer from API instability.
+    
+    #with open(fname, "r") as fin:
+    #    options = ruamel.yaml.load(fin, Loader=ruamel.yaml.Loader)
+    with ruamel.yaml.YAML(typ="safe") as yaml, open(fname, "r") as fin:
+        options = yaml.load(fin)
+
     if "parameters" not in options.keys():
         raise ValueError("parameters to fit must be specified")
     return options

--- a/moments/LD/Numerics.py
+++ b/moments/LD/Numerics.py
@@ -193,7 +193,8 @@ def integrate(
     Y,
     nu,
     T,
-    dt=0.001,
+    dt=None,
+    dt_fac=0.1,
     theta=0.001,
     rho=None,
     m=None,
@@ -225,6 +226,8 @@ def integrate(
     if num_pops > 1 and m is not None:
         if np.any(np.array(m) != 0):
             Mh, Mld = migration(num_pops, m, frozen=frozen, rho=rho)
+
+    dt = T * dt_fac
 
     dt_last = dt
     nus_last = nus
@@ -387,7 +390,7 @@ def steady_state(nus, m=None, rho=None, theta=0.001, selfing_rate=None):
         Migration must allow all sampled lineages to coalesce in finite time,
         so that populations must be connected via migration. This is unused
         when there is a single population given by `nus`.
-    :param rho: The population size-scaled recombination rate, or list of rates, 4*Ne*r. 
+    :param rho: The population size-scaled recombination rate, or list of rates, 4*Ne*r.
     :param theta: The population size-scaled mutation rate, 4*Ne*u.
     :param selfing_rate: List of selfing rates, with same length as `nus`. If
         not given, we assume selfing rates are 0 in each population.

--- a/moments/Manips.py
+++ b/moments/Manips.py
@@ -659,10 +659,18 @@ def __nnls_mod__(A, b):
     w = zeros((n,), dtype=double)
     zz = zeros((m,), dtype=double)
     index = zeros((n,), dtype=int)
-    try:
-        x, rnorm, mode = _nnls.nnls(A, m, n, b, w, zz, index, -1)
-    except:
-        x, rnorm, mode = _nnls.nnls(A, m, n, b, w, zz, index)
+
+    # It's unclear to me (APR) what is going on
+    # as far as which nnls function gets called
+    if sp.__version__ < "1.12":
+        try:
+            x, rnorm, mode = _nnls.nnls(A, m, n, b, w, zz, index, -1)
+        except:
+            x, rnorm, mode = _nnls.nnls(A, m, n, b, w, zz, index)
+    else:
+        x, rnorm = _nnls.nnls(A, b)
+        mode = 1
+
     if mode != 1:
         warnings.warn(
             "Too many iterations in nnls. This usually occurs under "

--- a/tests/test_LD.py
+++ b/tests/test_LD.py
@@ -433,6 +433,24 @@ class FStatistics(unittest.TestCase):
         self.assertTrue(y.f2(0, 1) == -y.f4(0, 1, 1, 0))
 
 
+class DplusStatistic(unittest.TestCase):
+    def setUp(self):
+        self.startTime = time.time()
+
+    def tearDown(self):
+        t = time.time() - self.startTime
+        print("%s: %.3f seconds" % (self.id(), t))
+
+    def test_steady_state(self):
+        # at steady state, we expect it to be theta**2 as r -> 1/2 and
+        # 2*theta**2 at r=0
+        theta = 0.001
+        y = moments.LD.Demographics1D.snm(theta=theta, rho=[0, 1000])
+        H2 = y.H2(0)
+        self.assertTrue(np.isclose(H2[0], 2 * theta ** 2))
+        self.assertTrue(np.isclose(H2[1], theta ** 2))
+
+
 # Older steady state functions
 def steady_state(theta=0.001, rho=None, selfing_rate=None):
     if selfing_rate is None:

--- a/tests/test_LD.py
+++ b/tests/test_LD.py
@@ -580,7 +580,7 @@ class SteadyState(unittest.TestCase):
                     num_pops=1,
                 )
                 y = y.split(0)
-                y.integrate(nus, 40, rho=rho, m=m, selfing=selfing_rate)
+                y.integrate(nus, 40, rho=rho, m=m, selfing=selfing_rate, dt_fac=0.02)
                 y2 = moments.LD.LDstats(
                     moments.LD.Numerics.steady_state(
                         nus,


### PR DESCRIPTION
Two commits. One lets you get H2 (i.e., D-plus) from LD statistics, either within or between populations and either as a phased or unphased statistic. The other commit removes the hard-coded `dt` in LD integration and replaces it with a `dt_fac`, as in SFS integration. This helps with integrating long time durations more efficiently.