### PR TITLE
Mutation rate handling in Demes-SFS

### DIFF
--- a/docs/data/msl_best_fit_model.yaml
+++ b/docs/data/msl_best_fit_model.yaml
@@ -5,6 +5,6 @@ generation_time: 29
 demes:
 - name: MSL
   epochs:
-  - {end_time: 438036.56125932775, start_size: 10852.074100961343}
-  - {end_time: 22028.57540856056, start_size: 25030.347289244255}
-  - {end_time: 0, start_size: 25030.347289244255, end_size: 65992.01795700718}
+  - {end_time: 438036.5612659915, start_size: 10852.074100910682}
+  - {end_time: 22028.575409347046, start_size: 25030.34728912296}
+  - {end_time: 0, start_size: 25030.34728912296, end_size: 65992.01795522582}

--- a/docs/extensions/demes.rst
+++ b/docs/extensions/demes.rst
@@ -265,7 +265,7 @@ We can compare the neutral and selected spectra:
     ax = plt.subplot(111)
     ax.semilogy(fs_yri, "-o", ms=6, lw=1, mfc="w", label="Neutral");
     ax.semilogy(fs_yri_sel, "-o", ms=3, lw=1,
-        label=f"Selected, $\gamma={gamma}$, $h={h}$");
+        label=f"Selected, $\\gamma={gamma}$, $h={h}$");
     ax.set_ylabel("Density");
     ax.set_xlabel("Derived allele count");
     ax.legend();

--- a/moments/Demes/Demes.py
+++ b/moments/Demes/Demes.py
@@ -8,6 +8,7 @@ import math
 import copy
 import numpy as np
 import demes
+import warnings
 
 import moments
 import moments.LD
@@ -15,19 +16,35 @@ import moments.LD
 
 def SFS(
     g,
-    sampled_demes,
-    sample_sizes,
+    sampled_demes=None,
+    sample_sizes=None,
     sample_times=None,
-    Ne=None,
+    samples=None,
     unsampled_n=4,
     gamma=None,
     h=None,
+    theta=None,
+    u=None,
+    reversible=False,
+    L=1,
 ):
     """
-    Takes a deme graph and computes the SFS. ``demes`` is a package for
-    specifying demographic models in a user-friendly, human-readable YAML
-    format. This function automatically parses the demographic description
-    and returns a SFS for the specified populations and sample sizes.
+    Compute the SFS from a ``demes``-specified demographic model.
+    ``demes`` is a package for specifying demographic models in a
+    user-friendly, human-readable YAML format. This function
+    automatically parses the demographic model and returns the SFS
+    for the specified populations, sample sizes, and (optionally)
+    sampling times.
+
+    Selection and dominance can be specified as a single value for
+    all populations, or on a per-deme basis using a dictionary
+    mapping deme name to the coefficient (defaults can also be set
+    if multiple demes have the same selection or dominance
+    coefficient). The mutation rate can be given as either a
+    per-base rate (possibly multiplied by the sequence length),
+    or as a population size-scaled rate. If mutation rates are not
+    given, the SFS is scaled by `4*N_e`, so that multiplying the
+    output SFS by `u` results in a properly scaled SFS.
 
     :param g: A ``demes`` DemeGraph from which to compute the SFS.
     :type g: :class:`demes.DemeGraph`
@@ -44,10 +61,7 @@ def SFS(
         ``sampled_demes``, giving the sampling times for each sampled
         deme. Sampling times are given in time units of the original deme graph,
         so might not necessarily be generations (e.g. if ``g.time_units`` is years)
-    :type sample_times: list of floats, optional
-    :param Ne: reference population size. If none is given, we use the initial
-        size of the root deme.
-    :type Ne: float, optional
+    :type sample_times: list of scalars, optional
     :param unsampled_n: The default sample size of unsampled demes, which must be
         greater than or equal to 4.
     :type unsampled_n: int, optional
@@ -59,7 +73,7 @@ def SFS(
         assigned a selection coefficient of zero. A non-zero default selection
         coefficient can be provided, using the key `_default`. See the Demes
         exension documentation for more details and examples.
-    :type gamma: float or dict
+    :type gamma: scalar or dict
     :param h: The dominance coefficient(s). Defaults to additivity (or genic
         selection). Can be given as a scalar value, in which case all populations
         have the same dominance coefficient. Alternatively, can be given as a
@@ -68,13 +82,53 @@ def SFS(
         coefficient of 1/2 (additivity). A different default dominance
         coefficient can be provided, using the key `_default`. See the Demes
         exension documentation for more details and examples.
-    :type h: float or dict
+    :type h: scalar or dict
+    :param theta: The scaled mutation rate(s), 4*Ne*u. When simulating under the
+        infinite sites model (the default mutation model), `theta` should be given
+        as a scalar value greater than zero. If it is not provided, it is computed
+        using the input value of `u` as 4*Ne*u. If `u` is not provided, then
+        the SFS is scaled by 4*Ne, and the user can recover a properly scaled SFS
+        by multiplying it by `u` or `u*L`. When simulating under the reversible
+        mutation model (with `reversible=True`), `theta` may be a list of length
+        2 and both the forward and backward scaled mutation rates must be less
+        than 1.
+    :type theta: scalar or list of length 2
+    :param u: The per-base mutation rate. When simulating under the infinite sites
+        model (the default mutation model), `u` should be a scalar. When simulating
+        under the reversible mutation model (with `reversible=True`), `u` may
+        be a list of length 2, and mutation rate(s) must be small enough so that
+        the product of `4*Ne*u` is less than 1.
+    :type u: scalar or list of length 2
+    :param L: The effective sequence length, which may be used along with `u` to
+        set the total mutation rate. Defaults to 1, and it must be 1 when using
+        the reversible mutation model.
+    :type L: scalar
     :return: A ``moments`` site frequency spectrum, with dimension equal to the
         length of ``sampled_demes``, and shape equal to ``sample_sizes`` plus one
         in each dimension, indexing the allele frequency in each deme from 0
         to n[i], where i is the deme index.
     :rtype: :class:`moments.Spectrum`
     """
+    # could specify samples as a dict instead of sampled_demes and sample_sizes
+    if samples is None:
+        if sampled_demes is None or sample_sizes is None:
+            raise ValueError(
+                "must specify either samples (as a dict mapping demes to sample sizes,"
+                " or specify both sampled_demes and sample_times"
+            )
+    else:
+        if type(samples) is not dict:
+            raise ValueError("samples must be a dict mapping demes to sample sizes")
+        if sampled_demes is not None or sample_sizes is not None:
+            raise ValueError(
+                "if samples is given as dict, cannot "
+                "specify sampled_demes or sample_sizes"
+            )
+        if sample_times is not None:
+            raise ValueError("if samples is given as dict, cannot specify sample times")
+        sampled_demes = list(samples.keys())
+        sample_sizes = list(samples.values())
+
     if len(sampled_demes) != len(sample_sizes):
         raise ValueError("sampled_demes and sample_sizes must be same length")
     if sample_times is not None and len(sampled_demes) != len(sample_times):
@@ -119,11 +173,14 @@ def SFS(
         if t < g[d].end_time or t >= g[d].start_time:
             raise ValueError("sample time for {deme} must be within its time span")
 
+    # get reference Ne from demes model
+    Ne = _get_root_Ne(g)
+
     # check selection and dominance inputs
     if gamma is not None:
         if "_default" in g:
             raise ValueError(
-                "Cannot use `_default` as a deme name when gamma is not None"
+                "Cannot use `_default` as a deme name when selection is specified"
             )
         if type(gamma) is dict:
             for k in gamma.keys():
@@ -134,6 +191,48 @@ def SFS(
             for k in h.keys():
                 if k != "_default" and k not in g:
                     raise ValueError(f"Deme {k} in h, but {k} not in input graph")
+
+    # set up the mutation rates as needed
+    if theta is None:
+        if u is None:
+            u = 1
+        if np.isscalar(u):
+            theta = 4 * Ne * u * L
+        else:
+            if np.ndim(u) != 1 or len(u) != 2:
+                raise ValueError(
+                    "Mutation rates must be a list of length 2 when using "
+                    "the reversible mutation model"
+                )
+            theta = [4 * Ne * u[0], 4 * Ne * u[1]]
+    else:
+        if u is not None:
+            raise ValueError("Only one of u or theta may be specified")
+
+    # if a scalar, must be positive; if list-like, must be length 2 and both positive
+    if not reversible:
+        if not np.isscalar(theta):
+            raise ValueError(
+                "Mutation rate must be a scalar value for the default ISM model"
+            )
+        if theta <= 0:
+            raise ValueError("Mutation rate must be positive")
+    if reversible:
+        if L != 1:
+            raise ValueError(
+                "Sequence length L must be 1 when using the reversible mutation model"
+            )
+        if np.isscalar(theta):
+            theta = [theta, theta]
+        if np.ndim(theta) != 1 or len(theta) != 2:
+            raise ValueError(
+                "Mutation rates must be a list of length 2 when using "
+                "the reversible mutation model"
+            )
+        if theta[0] <= 0 or theta[1] <= 0:
+            raise ValueError("Mutation rates must be positive")
+        if theta[0] >= 1 or theta[1] >= 1:
+            raise ValueError("Mutation rates too large for reversible mutation model")
 
     # get the list of demographic events from demes, which is a dictionary with
     # lists of splits, admixtures, mergers, branches, and pulses
@@ -181,10 +280,10 @@ def SFS(
         mig_mats,
         Ts,
         frozen_pops,
-        1,  # theta
+        theta=theta,
         gamma=gamma,
         h=h,
-        reversible=False,  # only ISM available
+        reversible=reversible,
     )
 
     fs = _reorder_fs(fs, sampled_pops)
@@ -206,11 +305,15 @@ def LD(
     g, sampled_demes, sample_times=None, rho=None, theta=0.001, r=None, u=None, Ne=None
 ):
     """
-    Takes a deme graph and computes the LD stats. ``demes`` is a package for
-    specifying demographic models in a user-friendly, human-readable YAML
-    format. This function automatically parses the demographic description
-    and returns a LD for the specified populations and recombination and
-    mutation rates.
+    Compute LD statistics from a ``demes``-specified demographic model.
+    ``demes`` is a package for specifying demographic models in a
+    user-friendly, human-readable YAML format. This function
+    automatically parses the demographic model and returns LD statistics
+    for the specified populations and (optionally) sampling times.
+
+    NOTE: Future versions will change the behavior of mutation and recombination
+    rate scaling, so that Ne isn't required as an input parameter but is instead
+    read directly from the demes model.
 
     :param g: A ``demes`` DemeGraph from which to compute the LD.
     :type g: :class:`demes.DemeGraph`
@@ -384,7 +487,9 @@ def _augment_with_ancient_samples(g, sampled_demes, sample_times):
             sd_frozen = sd + f"_sampled_{'_'.join(str(float(st + t)).split('.'))}"
             # update names of sampled demes
             sampled_demes[ii] = sd_frozen
-            deme_sample_times = [y for x, y in zip(sampled_demes, sample_times) if x == sd]
+            deme_sample_times = [
+                y for x, y in zip(sampled_demes, sample_times) if x == sd
+            ]
             if st > 0:
                 # add the frozen branch, as sample time is nonzero
                 frozen_demes.append(sd_frozen)
@@ -524,6 +629,12 @@ def _get_integration_parameters(g, demes_present, frozen_list, Ne=None):
 
     if Ne is None:
         Ne = _get_root_Ne(g)
+    else:
+        if Ne != _get_root_Ne(g):
+            warnings.warn(
+                "Input Ne is different from root population initial size, "
+                "subsequent population size scaling may be incorrect"
+            )
 
     for interval, live_demes in sorted(demes_present.items())[::-1]:
         # get intergration time for interval
@@ -826,9 +937,11 @@ def _compute_sfs(
         theta_fd = theta[0]
         theta_bd = theta[1]
         assert theta_fd < 1 and theta_bd < 1
+        mask_corners = False
     else:
         # theta is a scalar
-        assert type(theta) in [int, float]
+        assert np.isscalar(theta)
+        mask_corners = True
 
     integration_intervals = sorted(list(demes_present.keys()))[::-1]
     root_deme = demes_present[integration_intervals[0]][0]
@@ -861,7 +974,7 @@ def _compute_sfs(
         )
         if h0 != 0.5:
             raise ValueError("can only use h=0.5 with reversible mutation model")
-    fs = moments.Spectrum(fs, pop_ids=[root_deme])
+    fs = moments.Spectrum(fs, pop_ids=[root_deme], mask_corners=mask_corners)
 
     # for each set of demographic events and integration epochs, step through
     # integration, apply events, and then reorder populations to align with demes

--- a/moments/Demes/DemesUtil.py
+++ b/moments/Demes/DemesUtil.py
@@ -5,8 +5,9 @@ import math
 
 def slice(g, t):
     """
-    Slice a Demes graph at a given time, return the top portion with times shifted
-    to the slice time.
+    Slice a Demes graph at a given time, returning the portion of the
+    demographic model above the given time, and all model times are
+    shifted to the specified slice time.
 
     :param g: The input resolved Demes graph.
     :param t: The time in the past at which to slice the graph.

--- a/moments/Spectrum_mod.py
+++ b/moments/Spectrum_mod.py
@@ -924,7 +924,7 @@ class Spectrum(np.ma.masked_array):
             ns = self.sample_sizes
             nbar = np.mean(ns)
             nsum = np.sum(ns)
-            nc = (nsum - np.sum(ns**2) / nsum) / (r - 1)
+            nc = (nsum - np.sum(ns ** 2) / nsum) / (r - 1)
 
             # counts_per_pop is an r+1 dimensional array, where the last axis simply
             # records the indices of the entry.
@@ -1023,11 +1023,11 @@ class Spectrum(np.ma.masked_array):
 
         # See immediately after Eq. 12
         theta = self.Watterson_theta()
-        theta_sq = s * (s - 1.0) / (an**2 + bn)
+        theta_sq = s * (s - 1.0) / (an ** 2 + bn)
 
         # Eq. 14
         var = (n / (2.0 * (n - 1.0)) - 1.0 / an) * theta + (
-            bn / an**2
+            bn / an ** 2
             + 2.0 * (n / (n - 1.0)) ** 2 * bn
             - 2 * (n * bn - n + 1.0) / ((n - 1.0) * an)
             - (3.0 * n + 1.0) / (n - 1.0)
@@ -1073,11 +1073,11 @@ class Spectrum(np.ma.masked_array):
         a1 = np.sum(1.0 / np.arange(1, n))
         a2 = np.sum(1.0 / np.arange(1, n) ** 2)
         b1 = (n + 1) / (3 * (n - 1))
-        b2 = 2 * (n**2 + n + 3) / (9 * n * (n - 1))
+        b2 = 2 * (n ** 2 + n + 3) / (9 * n * (n - 1))
         c1 = b1 - 1.0 / a1
-        c2 = b2 - (n + 2) / (a1 * n) + a2 / a1**2
+        c2 = b2 - (n + 2) / (a1 * n) + a2 / a1 ** 2
 
-        C = np.sqrt((c1 / a1) * S + c2 / (a1**2 + a2) * S * (S - 1))
+        C = np.sqrt((c1 / a1) * S + c2 / (a1 ** 2 + a2) * S * (S - 1))
 
         return (pihat - theta) / C
 
@@ -2080,10 +2080,10 @@ class Spectrum(np.ma.masked_array):
         sample_sizes=None,
         sample_times=None,
         samples=None,
-        Ne=None,
         unsampled_n=4,
         gamma=None,
         h=None,
+        theta=1,
     ):
         """
         Takes a deme graph and computes the SFS. ``demes`` is a package for
@@ -2117,9 +2117,6 @@ class Spectrum(np.ma.masked_array):
             deme. Sampling times are given in time units of the original deme graph,
             so might not necessarily be generations (e.g. if ``g.time_units`` is years)
         :type sample_times: list of floats, optional
-        :param Ne: reference population size. If none is given, we use the initial
-            size of the root deme.
-        :type Ne: float, optional
         :param unsampled_n: The default sample size of unsampled demes, which must be
             greater than or equal to 4.
         :type unsampled_n: int, optional
@@ -2141,6 +2138,13 @@ class Spectrum(np.ma.masked_array):
             coefficient can be provided, using the key `_default`. See the Demes
             exension documentation for more details and examples.
         :type h: float or dict
+        :param theta: The population-size scaled mutation rate (4*Ne*u or 4*Ne*u*L).
+            The default value is 1. For more control of mutation rates and mutation
+            models (including using a reversible mutation model), please use
+            `moments.Demes.SFS`, which has options to specify theta, the per-base
+            mutation rate u, and/or a reversible mutation model that allows for
+            different forward and backward mutation rates.
+        :type theta: scalar
         :return: A ``moments`` site frequency spectrum, with dimension equal to the
             length of ``sampled_demes``, and shape equal to ``sample_sizes`` plus one
             in each dimension, indexing the allele frequency in each deme from 0
@@ -2152,36 +2156,16 @@ class Spectrum(np.ma.masked_array):
         else:
             dg = g
 
-        if samples is None:
-            if sampled_demes is None or sample_sizes is None:
-                raise ValueError(
-                    "must specify either samples (as a dict mapping demes to sample sizes,"
-                    " or specify both sampled_demes and sample_times"
-                )
-        elif samples is not None:
-            if type(samples) is not dict:
-                raise ValueError("samples must be a dict mapping demes to sample sizes")
-            if sampled_demes is not None or sample_sizes is not None:
-                raise ValueError(
-                    "if samples is given as dict, cannot "
-                    "specify sampled_demes or sample_sizes"
-                )
-            if sample_times is not None:
-                raise ValueError(
-                    "if samples is given as dict, cannot specify sample times"
-                )
-            sampled_demes = list(samples.keys())
-            sample_sizes = list(samples.values())
-
         fs = moments.Demes.Demes.SFS(
             dg,
             sampled_demes,
             sample_sizes,
             sample_times=sample_times,
-            Ne=Ne,
+            samples=samples,
             unsampled_n=unsampled_n,
             gamma=gamma,
             h=h,
+            theta=theta,
         )
         return fs
 


### PR DESCRIPTION
This adds some functionality for specifying mutation rates in the Demes-SFS methods, as brought up in #153.

The function to compute the SFS from a demes-formatted graph is `moments.Demes.SFS(g, samples, ...)`. The Spectrum class function `moments.Spectrum.from_demes(g, samples, ...)` acts as a wrapper for this function. This PR changes `moments.Spectrum.from_demes(...)` to take `theta` as a keyword argument, and it defaults to 1.

More functionality is provided in `Demes.SFS()`. Now the function `moments.Demes.SFS(...)` can take `theta` (the pop-size scaled mutation rate) or `u` (the "raw" mutation rate), but it can't take both. If `u` is provided, then `theta` is determined by finding the ancestral `Ne` in the root deme. If neither `theta` nor `u` are provided, then `Ne` is again determined by the root deme's initial size, and the SFS is scaled by 4*Ne, so that multiplying after calculating by u (or uL) results in a properly scaled SFS.