### PR TITLE
Add Demes API docs

### DIFF
--- a/docs/api/api_demes.rst
+++ b/docs/api/api_demes.rst
@@ -1,0 +1,35 @@
+.. _sec_demes_api:
+
+===========================
+API for ``demes`` functions
+===========================
+
+Computing statistics from ``demes``
+-----------------------------------
+
+.. autofunction:: moments.Demes.SFS
+
+.. autofunction:: moments.Demes.LD
+
+Running SFS inference using ``demes``
+-------------------------------------
+
+.. autofunction:: moments.Demes.Inference.optimize
+
+.. autofunction:: moments.Demes.Inference.uncerts
+
+Running LD inference using ``demes``
+------------------------------------
+
+.. autofunction:: moments.Demes.Inference.optimize_LD
+
+.. autofunction:: moments.Demes.Inference.uncerts_LD
+
+.. autofunction:: moments.Demes.Inference.compute_bin_stats
+
+Manipulating ``demes`` models to compute statistics
+---------------------------------------------------
+
+.. autofunction:: moments.Demes.DemesUtil.slice
+
+.. autofunction:: moments.Demes.DemesUtil.swipe

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,3 +55,4 @@ Welcome to moments's documentation!
 
    api/api_moments
    api/api_ld
+   api/api_demes

--- a/moments/Demes/DemesUtil.py
+++ b/moments/Demes/DemesUtil.py
@@ -93,7 +93,7 @@ def swipe(g, t):
     ..note::
         Don't really like this function name... any suggestions?
 
-    Returns a new demes graph with demography about the given time removed.
+    Returns a new demes graph with demography above the given time removed.
     Demes that existed before that time are removed, and demes that overlap
     with that time are given a constant size equal to their size at that time
     extending into the past.

--- a/moments/Demes/Inference.py
+++ b/moments/Demes/Inference.py
@@ -1256,7 +1256,7 @@ def uncerts_LD(
 ):
     """
     Compute uncertainties for fitted parameters, using the output YAML from
-    ``moments.Demes.Invascript:void(0); ference.optimize_LD()``.
+    ``moments.Demes.Inference.optimize_LD()``.
     """
     func_calls = 0
 


### PR DESCRIPTION
Include API docs for Demes functionality in the documentation. Before merging this PR, the documentation should be completed for a few functions, namely the LD inference, uncertainty calculation, and the slice/swipe functions.