### PR TITLE
Demes-LD mutation rate scaling

### DIFF
--- a/moments/LD/LDstats_mod.py
+++ b/moments/LD/LDstats_mod.py
@@ -789,7 +789,6 @@ class LDstats(list):
         theta=0.001,
         r=None,
         u=None,
-        Ne=None,
     ):
         """
         Takes a deme graph and computes the LD stats. ``demes`` is a package for
@@ -812,16 +811,13 @@ class LDstats(list):
             so might not necessarily be generations (e.g. if ``g.time_units`` is years)
         :type sample_times: list of floats, optional
         :param rho: The population-size scaled recombination rate(s). Can be None, a
-            non-negative float, or a list of values. Cannot be used with ``Ne``.
-        :param theta: The population-size scaled mutation rate. Cannot be used with ``Ne``.
+            non-negative float, or a list of values.
+        :param theta: The population-size scaled mutation rate. This defaults to
+            ``theta=0.001``, which is very roughly what is observed in humans.
         :param r: The raw recombination rate. Can be None, a non-negative float, or a
-            list of values. Must be used with ``Ne``.
-        :param u: The raw per-base mutation rate. Must be used with ``Ne``, in which case
-            ``theta`` is set to ``4 * Ne * u``.
-        :param Ne: The reference population size. If none is given, we use the initial
-            size of the root deme. For use with ``r`` and ``u``, to compute ``rho`` and
-            ``theta``. If ``rho`` and/or ``theta`` are given, we do not pass Ne.
-        :type Ne: float, optional
+            list of values.
+        :param u: The raw per-base mutation rate. ``theta`` is set to ``4 * Ne * u``,
+            where ``Ne`` is the reference population size from the root deme.
         :return: A ``moments.LD`` LD statistics object, with number of populations equal
             to the length of ``sampled_demes``.
         :rtype: :class:`moments.LD.LDstats`
@@ -840,7 +836,6 @@ class LDstats(list):
             theta=theta,
             r=r,
             u=u,
-            Ne=Ne,
         )
         return y
 

--- a/tests/test_Demes.py
+++ b/tests/test_Demes.py
@@ -1707,18 +1707,22 @@ class TestAncientSamples(unittest.TestCase):
         g = b.resolve()
 
         # test some results
-        y = Demes.LD(g, sampled_demes=["deme1", "deme2"], sample_times=[100, 200])
-        y2 = moments.LD.Demographics1D.snm()
+        theta = 0.001
+        y = Demes.LD(
+            g, sampled_demes=["deme1", "deme2"], sample_times=[100, 200], theta=theta
+        )
+        y2 = moments.LD.Demographics1D.snm(theta=theta)
         y2 = y2.split(0)
-        y2.integrate([0.5, 2.0], 0.125, m=[[0, 8], [8, 0]])
+        y2.integrate([0.5, 2.0], 0.125, m=[[0, 8], [8, 0]], theta=theta)
         y2 = y2.pulse_migrate(0, 1, 0.1)
-        y2.integrate([0.5, 2.0], 0.075, m=[[0, 8], [8, 0]])
+        y2.integrate([0.5, 2.0], 0.075, m=[[0, 8], [8, 0]], theta=theta)
         y2 = y2.split(1)
         y2.integrate(
             [0.5, 2.0, 2.0],
             0.025,
             m=[[0, 8, 0], [8, 0, 0], [0, 0, 0]],
             frozen=[False, False, True],
+            theta=theta,
         )
         y2 = y2.marginalize([1])
         self.assertTrue(np.allclose(y[0], y2[0]))


### PR DESCRIPTION
In `moments.LD.from_demes(...)`, theta defaults to 0.001, which is very roughly the human value for this parameter.

In `moments.Demes.LD(...)`, both `u` and `theta` default to `None`. Thus, theta is set to 4*Ne, and to recover properly scaled LD statistics, the two-locus stats should be multiplied by u^2 and the single-locus stats should be multiplied by u.