### PR TITLE
Add *.pyx files to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,4 +5,5 @@ include LICENSE.txt
 #recursive-include doc *.html *.css *.js manual.pdf *.tex *.py *.fs *.bib
 #recursive-include examples *
 recursive-include tests *
+recursive-include moments *.py *.pyx
 #global-exclude *.msout *.swp *.pyc seedms *.png


### PR DESCRIPTION
The Cython source files (moments/**.pyx) are not part of MANIFEST.in.
Their absence causes #166.
