### PR TITLE
move package setup from setup.py to pyproject.toml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,3 +54,14 @@ jobs:
         run: |
           python -m pip install build
           python -m build .
+
+      - name: Test pip install from wheel in fresh venv
+        run: |
+            cd dist
+            python -m venv venv
+            source venv/bin/activate
+            python -m pip install --no-cache-dir ./moments*-*.whl
+            python -c "import moments;print(moments.__file__)"
+            python -c "import moments;print(moments.__version__)"
+            deactivate
+            rm -rf venv

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ _build/
 *.gz
 moments.egg-info
 .DS_Store
+_version.py
 
 UNKNOWN.egg-info/
 dist/

--- a/moments/_version.py
+++ b/moments/_version.py
@@ -1,4 +1,0 @@
-"""Version information."""
-
-# The following line *must* be the last in the module, exactly as formatted:
-__version__ = "1.1.18"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 requires = [
     "setuptools",
+    "setuptools_scm>=8",
     "wheel",
     "numpy==1.12.1; python_version=='3.6'",
     "numpy==1.15.4; python_version=='3.7'",
@@ -9,6 +10,34 @@ requires = [
     "numpy==1.22.3; python_version=='3.10'",
     # do not pin numpy on future versions of python to avoid incompatible numpy and python versions
     "numpy; python_version>='3.11'",
-    "Cython>=0.25.0"
+    "Cython>=0.25.0",
+    "bdist_mpkg"
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+write_to = "moments/_version.py"
+
+[project]
+name = "moments"
+authors = [
+    {name = "Aaron Ragsdale", email = "apgragsdale@wisc.edu"},
+    {name = "Julien Jouganous"},
+    {name = "Simon Gravel", email = "simon.gravel@mcgill.ca"},
+    {name = "Ryan Gutenkunst"}
+]
+license = {text = "MIT"}
+requires-python = ">=3.9, <3.13"
+dynamic = ["version"]
+dependencies=[
+    "numpy >=1.12.1",
+    "cython >=0.25",
+    "scipy >=1.3",
+    "mpmath >=1.0",
+    "demes >=0.2",
+]
+
+[project.urls]
+Repository = "https://github.com/MomentsLD/moments"
+Documentation = "https://moments.readthedocs.io"
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ requires = [
     # do not pin numpy on future versions of python to avoid incompatible numpy and python versions
     "numpy; python_version>='3.11'",
     "Cython>=0.25.0",
-    "bdist_mpkg"
 ]
 build-backend = "setuptools.build_meta"
 

--- a/setup.py
+++ b/setup.py
@@ -1,27 +1,9 @@
-# Importing these adds a 'bdist_mpkg' option that allows building binary
-# packages on OS X.
-try:
-    import setuptools
-    import bdist_mpkg
-except ImportError:
-    pass
-
-
 from distutils.core import setup
 from distutils.extension import Extension
+from Cython.Build import cythonize
+from Cython.Distutils import build_ext
 
-try:
-    from Cython.Build import cythonize
-    from Cython.Distutils import build_ext
-except ImportError as e:
-    print("cython not installed, please install cython first")
-    raise e
-
-try:
-    import numpy as np
-except ImportError as e:
-    print("numpy not installed, please install numpy first")
-    raise e
+import numpy as np
 
 # cython extensions for moments
 extensions = [
@@ -70,10 +52,6 @@ extensions = [
 ]
 
 setup(
-    name="moments",
-    version=open("moments/_version.py").readlines()[-1].split()[-1].strip("\"'"),
-    author="Aaron Ragsdale, Julien Jouganous, Simon Gravel, Ryan Gutenkunst",
-    author_email="aaron.ragsdale@mail.mcgill.ca, simon.gravel@mcgill.ca",
     url="https://github.com/MomentsLD/moments",
     packages=[
         "moments",
@@ -82,15 +60,6 @@ setup(
         "moments.LD",
         "moments.Demes",
     ],
-    license="MIT",
     cmdclass={"build_ext": build_ext},
     ext_modules=cythonize(extensions, language_level="3"),
-    python_requires=">=3.6",
-    install_requires=[
-        "numpy >=1.12.1",
-        "cython >=0.25",
-        "scipy >=1.3",
-        "mpmath >=1.0",
-        "demes >=0.2",
-    ],
 )


### PR DESCRIPTION
Update the package configuration to current Python "standards":

* move as much as possible from `setup.py` to `pyproject.toml`.
* use `setuptools_scm` for auto-generating the package versions.
* Remove use of `bdist_mpkg`. This package creates "clickable" install files for macos. See [here](https://pypi.org/project/bdist_mpkg/). Using this causes warnings in CI.  It is also not necessary and possibly even undesirable.
   In most/all cases it would be preferable to build a wheel locally and then install that into a venv.