### PR TITLE
Change project name to moments-popgen

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -180,10 +180,13 @@ jobs:
           python -c "import moments;print(moments.__version__)"
           python -c "import moments;print(moments.__file__)"
               
-  upload_to_PyPI:
+  pypi-publish:
     name: Upload to PyPI
     runs-on: ubuntu-latest
     needs: ['manylinux2_28', 'manylinux2_28_test', 'manylinux2_28_test_install_wheel', 'macos_test_install_wheel']
+    environment: release
+    permissions:
+      id-token: write
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.12.1
@@ -198,5 +201,3 @@ jobs:
       - name: Publish distribution to PRODUCTION PyPI
         if: github.event_name == 'release'
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_UPLOAD }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,202 @@
+name: Build, test, and deploy wheels
+
+on:
+  schedule:
+    - cron: "0 0 1 * *"
+  release:
+    types: [created]
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.1
+        with:
+          access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+            submodules: true
+            fetch-depth: 0
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build sdist
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build -s .
+
+      - name: Upload sdist
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist
+
+  macos-wheels:
+    name: Build and test macOS wheels
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-14, macos-13]
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.1
+        with:
+          access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.17.0
+
+      - name: Upload Wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.os }}-wheels
+          path: wheelhouse
+
+  manylinux2_28:
+    name: Build and test Linux wheels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.1
+        with:
+          access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.17.0
+
+      - name: Upload Wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-wheels
+          path: wheelhouse
+
+  manylinux2_28_test:
+    name: Build package from source dist
+    runs-on: ubuntu-latest
+    needs: ['build_sdist']
+    strategy:
+      matrix:
+        python: [3.8, 3.9, "3.10", "3.11", "3.12"]
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.1
+        with:
+          access_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Download sdist
+        uses: actions/download-artifact@v4.1.4
+        with:
+          name: sdist
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install sdist into venv
+        run: |
+          python -m venv sdist_venv
+          source sdist_venv/bin/activate
+          python -m pip install --upgrade pip setuptools
+          python -m pip install *.gz
+          # The cd is to move us away from
+          # the project repo root where the module is not built
+          cd sdist_venv
+          python -c "import moments;print(moments.__version__)"
+          deactivate
+          rm -rf sdist_venv
+
+  # Test that wheels build in the docker cibuildwheel workflow
+  # can be installed on Ubuntu Linux, which is a different distro.
+  manylinux2_28_test_install_wheel:
+    name: Install the wheel on github runner
+    runs-on: ubuntu-latest
+    needs: ['manylinux2_28']
+    strategy:
+      matrix:
+        python: [3.8, 3.9, "3.10", "3.11", "3.12"]
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.1
+        with:
+          access_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download sdist
+        uses: actions/download-artifact@v4.1.4
+        with:
+          name: linux-wheels
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+      - name: install into venv
+        run: |
+          python -m venv venv
+          source venv/bin/activate
+          python -m pip install --no-cache-dir --only-binary=moments --pre --find-links . moments
+          python -m moments --includes
+          python -c "import moments;print(moments.__version__)"
+          python -c "import moments;print(moments.__file__)"
+
+  macos_test_install_wheel:
+    name: Install the wheel on github runner
+    runs-on: ${{ matrix.os }}
+    needs: ['macos-wheels']
+    strategy:
+      matrix:
+        python: ["3.11", "3.12"]
+        os: [macos-14, macos-13]
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.1
+        with:
+          access_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download sdist
+        uses: actions/download-artifact@v4.1.4
+        with:
+          name: ${{ matrix.os }}-wheels
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+      - name: install into venv
+        run: |
+          python -m venv venv
+          source venv/bin/activate
+          python -m pip install --no-cache-dir --only-binary=moments --pre --find-links . moments
+          python -m moments --includes
+          python -c "import moments;print(moments.__version__)"
+          python -c "import moments;print(moments.__file__)"
+              
+  upload_to_PyPI:
+    name: Upload to PyPI
+    runs-on: ubuntu-latest
+    needs: ['manylinux2_28', 'manylinux2_28_test', 'manylinux2_28_test_install_wheel', 'macos_test_install_wheel']
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.1
+        with:
+          access_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download all
+        uses: actions/download-artifact@v4.1.4
+      - name: Move to dist
+        run: |
+          mkdir dist
+          cp */*.{whl,gz} dist/.
+      - name: Publish distribution to PRODUCTION PyPI
+        if: github.event_name == 'release'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_UPLOAD }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "setuptools.build_meta"
 write_to = "moments/_version.py"
 
 [project]
-name = "moments"
+name = "moments-popgen"
 authors = [
     {name = "Aaron Ragsdale", email = "apgragsdale@wisc.edu"},
     {name = "Julien Jouganous"},
@@ -29,7 +29,7 @@ license = {text = "MIT"}
 requires-python = ">=3.9, <3.13"
 dynamic = ["version"]
 dependencies=[
-    "numpy >=1.12.1",
+    "numpy >=1.12.1, <2.0",
     "cython >=0.25",
     "scipy >=1.3",
     "mpmath >=1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,5 +38,16 @@ dependencies=[
 
 [project.urls]
 Repository = "https://github.com/MomentsLD/moments"
-Documentation = "https://moments.readthedocs.io"
+Documentation = "https://momentsld.github.io/moments/"
 
+[tool.cibuildwheel]
+test-requires = "pytest"
+test-command = "pytest {project}/tests"
+build-frontend = "build"
+
+[tool.cibuildwheel.macos]
+build = "cp3{11,12}-*"
+
+[tool.cibuildwheel.linux]
+build = "cp*manylinux*"
+archs = "x86_64"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy<2.0
 cython~=0.29.0
 scipy
 mpmath

--- a/tests/test_LinearSystem.py
+++ b/tests/test_LinearSystem.py
@@ -37,7 +37,7 @@ class LinearSystemTestCase(unittest.TestCase):
         )
         dims = numpy.array([25])
         ljk = jk.calcJK13(int(dims[0] - 1))
-        s = LinearSystem_1D.calcS(dims, ljk)
+        s = LinearSystem_1D.calcS(dims[0], ljk)
         S = -0.1 * s
         self.assertTrue(numpy.allclose(S.todense(), S1ref))
 
@@ -50,7 +50,7 @@ class LinearSystemTestCase(unittest.TestCase):
         )
         dims = numpy.array([25])
         ljk = jk.calcJK23(int(dims[0] - 1))
-        s = LinearSystem_1D.calcS2(dims, ljk)
+        s = LinearSystem_1D.calcS2(dims[0], ljk)
         S = -1.0 * (1 - 2 * 0.1) * s
         self.assertTrue(numpy.allclose(S.todense(), S2ref))
 


### PR DESCRIPTION
This is in preparation to host moments on pypi. Because the name "moments" is already taken, we plan to rename the package to moments-popgen. Installing moments-popgen doesn't change that you would `import moments` in python. But it may change some other installation procedures, and allow for `pip install moments-popgen` directly.