### PR TITLE
Update installation docs and test wheels workflow

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -152,7 +152,7 @@ jobs:
         run: |
           python -m venv venv
           source venv/bin/activate
-          python -m pip install --no-cache-dir --only-binary=moments --pre --find-links . moments
+          python -m pip install --no-cache-dir --only-binary=moments-popgen --pre --find-links . moments-popgen
           python -m moments --includes
           python -c "import moments;print(moments.__version__)"
           python -c "import moments;print(moments.__file__)"
@@ -181,7 +181,7 @@ jobs:
         run: |
           python -m venv venv
           source venv/bin/activate
-          python -m pip install --no-cache-dir --only-binary=moments --pre --find-links . moments
+          python -m pip install --no-cache-dir --only-binary=moments-popgen --pre --find-links . moments-popgen
           python -m moments --includes
           python -c "import moments;print(moments.__version__)"
           python -c "import moments;print(moments.__file__)"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -6,7 +6,13 @@ on:
   release:
     types: [created]
   pull_request:
-    branches: [main, dev]
+    branches: [main, devel]
+  push:
+    branches: [main, devel]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build_sdist:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -153,7 +153,6 @@ jobs:
           python -m venv venv
           source venv/bin/activate
           python -m pip install --no-cache-dir --only-binary=moments-popgen --pre --find-links . moments-popgen
-          python -m moments --includes
           python -c "import moments;print(moments.__version__)"
           python -c "import moments;print(moments.__file__)"
 
@@ -182,7 +181,6 @@ jobs:
           python -m venv venv
           source venv/bin/activate
           python -m pip install --no-cache-dir --only-binary=moments-popgen --pre --find-links . moments-popgen
-          python -m moments --includes
           python -c "import moments;print(moments.__version__)"
           python -c "import moments;print(moments.__file__)"
               

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -188,7 +188,9 @@ jobs:
     name: Upload to PyPI
     runs-on: ubuntu-latest
     needs: ['manylinux2_28', 'manylinux2_28_test', 'manylinux2_28_test_install_wheel', 'macos_test_install_wheel']
-    environment: release
+    environment:
+      name: pypi
+      url: https://pypi.org/p/moments-popgen
     permissions:
       id-token: write
     steps:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -9,6 +9,9 @@ Python 2, we do not actively ensure that moments remains fully compatable with P
 Using pip
 =========
 
+.. todo::
+    Update docs when moments is installable via pip, as ``pip install moments-popgen``.
+
 A simple way to install ``moments`` is via ``pip``. ``numpy``, ``mpmath``, and ``cython``
 are install requirements, but installing ``moments`` directly from the git repository
 using ``pip`` should install these dependencies automatically:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ authors = [
     {name = "Ryan Gutenkunst"}
 ]
 license = {text = "MIT"}
-requires-python = ">=3.9, <3.13"
+requires-python = ">=3.8, <3.13"
 dynamic = ["version"]
 dependencies=[
     "numpy >=1.12.1, <2.0",


### PR DESCRIPTION
Previous merge introduced the `wheels.yml` workflow, which builds and tests wheels, and also has a block for publishing on PyPI in the case of a release tag.

There will probably be errors to start with...