### PR TITLE
Add readme to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies=[
     "mpmath >=1.0",
     "demes >=0.2",
 ]
+readme = "README.md"
 
 [project.urls]
 Repository = "https://github.com/MomentsLD/moments"


### PR DESCRIPTION
In tagging v.1.2.0-alpha.0, upload to pypi failed with
```
ERROR    `long_description` has syntax errors in markup and would not be        
rendered on PyPI.                                                      
No content rendered from RST source.
```

Quick google search suggested that the readme needs to be included in pyproject.toml.