### PR TITLE
Add F-statistic functions to Spectrum_mod

### DIFF
--- a/moments/Spectrum_mod.py
+++ b/moments/Spectrum_mod.py
@@ -1081,6 +1081,55 @@ class Spectrum(np.ma.masked_array):
 
         return (pihat - theta) / C
 
+    def f2(self, X, Y):
+        """
+        Returns :math:`f_2(X, Y) = (pX-pY)^2`, where :math:`p` are observed
+        allele frequencies in populations X and Y.
+
+        X, and Y can be specified as population ID strings, or as indexes
+        (but these cannot be mixed).
+
+        :param X: One of the populations, as index or population ID.
+        :param Y: The other population, as index or population ID.
+        :return: Patterson's f2 statistics.
+        """
+        if type(X) is int and type(Y) is int:
+            idx0 = X
+            idx1 = Y
+        elif type(X) is str and type(Y) is str:
+            if self.pop_ids is None:
+                raise ValueError("Populations given a strings, but pop_ids is None")
+            for _ in [X, Y]:
+                if _ not in self.pop_ids:
+                    raise ValueError(f"Population {_} is not in pop_ids")
+            idx0 = self.pop_ids.index(X)
+            idx1 = self.pop_ids.index(Y)
+        else:
+            raise ValueError(
+                "Populations X and Y must both be population indexes or IDs"
+            )
+
+        to_marginalize = [i for i in range(self.Npop) if i not in [idx0, idx1]]
+        fs = self.marginalize(to_marginalize)
+
+        n0, n1 = fs.sample_sizes
+        i0 = np.arange(n0 + 1)[:, np.newaxis]
+        i1 = np.arange(n1 + 1)[np.newaxis, :]
+
+        # To account for sampling bias
+        fac = (
+            i0 * (i0 - 1) / n0 / (n0 - 1)
+            - 2 * i0 * i1 / n0 / n1
+            + i1 * (i1 - 1) / n1 / (n1 - 1)
+        )
+        return np.sum(fac * fs)
+
+    def f3(X, Y, Z):
+        pass
+
+    def f4(X, Y, Z, W):
+        pass
+
     # Functions for resampling or generating "data" from an SFS
 
     def fixed_size_sample(self, nsamples, include_masked=False):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,9 @@ write_to = "moments/_version.py"
 name = "moments-popgen"
 authors = [
     {name = "Aaron Ragsdale", email = "apgragsdale@wisc.edu"},
-    {name = "Julien Jouganous"},
     {name = "Simon Gravel", email = "simon.gravel@mcgill.ca"},
-    {name = "Ryan Gutenkunst"}
+    {name = "Julien Jouganous"},
+    {name = "Ryan Gutenkunst"},
 ]
 license = {text = "MIT"}
 requires-python = ">=3.8, <3.13"

--- a/tests/test_Fstatistics.py
+++ b/tests/test_Fstatistics.py
@@ -1,0 +1,41 @@
+import os
+import unittest
+import numpy as np
+import moments
+import time
+import demes
+
+
+class FStatistics(unittest.TestCase):
+    def setUp(self):
+        self.startTime = time.time()
+
+    def tearDown(self):
+        t = time.time() - self.startTime
+        print("%s: %.3f seconds" % (self.id(), t))
+
+    def test_LD_equivalence(self):
+        y = moments.LD.Demographics2D.snm()
+        y = y.split(1)
+        y.integrate([1, 2, 3], 0.2)
+        self.assertTrue(y.f2(0, 1) == y.f3(0, 1, 1))
+        self.assertTrue(y.f2(0, 1) == y.f2(1, 0))
+        self.assertTrue(y.f2(0, 1) == y.f3(1, 0, 0))
+        self.assertTrue(y.f2(0, 1) == y.f4(0, 1, 0, 1))
+        self.assertTrue(y.f2(0, 1) == -y.f4(0, 1, 1, 0))
+
+    def test_F2_LD_against_SFS(self):
+        b = demes.Builder()
+        b.add_deme("anc", epochs=[dict(start_size=1000, end_time=200)])
+        b.add_deme("A", ancestors=["anc"], epochs=[dict(start_size=100, end_size=5000)])
+        b.add_deme("B", ancestors=["anc"], epochs=[dict(start_size=2000, end_size=500)])
+        b.add_migration(demes=["A", "B"], rate=1e-4)
+        g = b.resolve()
+
+        y = moments.Demes.LD(g, ["A", "B"], u=1e-6)
+        fs = moments.Demes.SFS(g, samples={"A": 20, "B": 20}, u=1e-6)
+
+        f2_LD = y.f2("A", "B")
+        f2_SFS = fs.f2("A", "B")
+
+        self.assertTrue(np.isclose(f2_LD, f2_SFS, rtol=2e-4))


### PR DESCRIPTION
An `LDstats` object has class functions to compute f2, f3 and f4 from the heterozygosity statistics. These are not currently available as SFS class functions. This PR adds these and tests them against the output of those same statistics as computed from the LD functions.