### PR TITLE
Remove unused scipy functions

### DIFF
--- a/moments/Spectrum_mod.py
+++ b/moments/Spectrum_mod.py
@@ -18,17 +18,6 @@ import itertools
 import warnings
 import demes
 
-# Account for difference in scipy installations.
-try:
-    from scipy.misc import comb
-except ImportError:
-    try:
-        from scipy.special import comb
-    except:
-        from scipy import comb
-from scipy.integrate import trapz
-from scipy.special import betainc
-
 import moments.Integration
 import moments.Integration_nomig
 from . import Numerics


### PR DESCRIPTION
Specifically, trapz, comb and betainc were not actually used in `Spectrum_mod`, and trying to import trapz was causing problems as it's deprecated in scipy.

Closes #185 