### PR TITLE
Invert rescaling parameter meaning

### DIFF
--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -61,6 +61,12 @@ If you use ``moments.TwoLocus`` in your research, please cite:
 Change log
 **********
 
+1.2.3
+=====
+
+- Invert meaning of rescaling parameter in ``moments.Demes.DemesUtil.rescale()``
+  to match standard conventions.
+
 1.2.0
 =====
 

--- a/moments/Demes/DemesUtil.py
+++ b/moments/Demes/DemesUtil.py
@@ -218,22 +218,25 @@ def rescale(g, Q=1):
     """
     Rescale a demes model by scaling factor ``Q``. This rescaling is done so
     that compount parameters (e.g., ``Ne*m``) remain constant. In the new
-    model, population sizes are ``Q*Ne``, model times are `'Q*T'`, and
-    migration rates are ``m/Q``.
+    model, population sizes are ``Ne/Q``, model times are `'T/Q'`, and
+    migration rates are ``m*Q``.
 
-    For example, setting ``Q=0.1`` will reduce all population sizes by a factor
+    For example, setting ``Q=10`` will reduce all population sizes by a factor
     of :math:`1/10`, all times will be reduced by that same amount, and
     migration rates will increase by a factor of 10 so that the product
     ``2*Ne*m`` remains constant.
 
     When simulating with mutation and recombination rates, or with selection,
-    those values should also be scaled by :math:`1/Q` to ensure that compound
+    those values should also be scaled by :math:`Q` to ensure that compound
     parameters remain constant.
+
+    Note: As of version 1.2.3, the meaning of ``Q`` has been inverted to
+    match standard convention for this scaling parameter.
 
     :param g: A ``demes`` demographic model.
     :type: :class:`demes.Graph`
     :param Q: The scaling factor. Population sizes and times are scaled by
-        multiplying values by ``Q``. Migration rates are scaled by dividing
+        dividing values by ``Q``. Migration rates are scaled by multiplying
         by ``Q``. Admixture and ancestry proportions are unchanged, though
         the timing of those events are scaled. Generation times and units
         are unchanged.
@@ -245,16 +248,16 @@ def rescale(g, Q=1):
         raise ValueError("Scaling factor Q must be positive and finite")
     d = g.asdict()
     for i, deme in enumerate(d["demes"]):
-        d["demes"][i]["start_time"] *= Q
+        d["demes"][i]["start_time"] /= Q
         for j, epoch in enumerate(d["demes"][i]["epochs"]):
-            d["demes"][i]["epochs"][j]["start_size"] *= Q
-            d["demes"][i]["epochs"][j]["end_size"] *= Q
-            d["demes"][i]["epochs"][j]["end_time"] *= Q
+            d["demes"][i]["epochs"][j]["start_size"] /= Q
+            d["demes"][i]["epochs"][j]["end_size"] /= Q
+            d["demes"][i]["epochs"][j]["end_time"] /= Q
     for i, mig in enumerate(d["migrations"]):
-        d["migrations"][i]["start_time"] *= Q
-        d["migrations"][i]["end_time"] *= Q
-        d["migrations"][i]["rate"] /= Q
+        d["migrations"][i]["start_time"] /= Q
+        d["migrations"][i]["end_time"] /= Q
+        d["migrations"][i]["rate"] *= Q
     for i, pulse in enumerate(d["pulses"]):
-        d["pulses"][i]["time"] *= Q
+        d["pulses"][i]["time"] /= Q
     b = demes.Builder.fromdict(d)
     return b.resolve()

--- a/tests/test_Demes.py
+++ b/tests/test_Demes.py
@@ -2081,9 +2081,9 @@ class TestDemesRescaling(unittest.TestCase):
         fsc = moments.Demes.SFS(g, samples=samples, theta=4 * Ne * u, L=L)
         self.assertTrue(np.allclose(fs, fsc))
 
-        for Q in [0.1, 0.5, 2]:
+        for Q in [10, 2, 0.1]:
             g2 = moments.Demes.DemesUtil.rescale(g, Q)
-            fs2 = moments.Demes.SFS(g2, samples=samples, u=u / Q, L=L)
+            fs2 = moments.Demes.SFS(g2, samples=samples, u=u * Q, L=L)
             self.assertTrue(np.allclose(fs, fs2))
             fs3 = moments.Demes.SFS(g2, samples=samples, theta=4 * Ne * u, L=L)
             self.assertTrue(np.allclose(fs, fs3))
@@ -2098,9 +2098,9 @@ class TestDemesRescaling(unittest.TestCase):
         u = 1e-8
         fs = moments.Demes.SFS(g, samples=samples, u=u)
 
-        for Q in [0.1, 0.5, 2]:
+        for Q in [10, 2, 0.5]:
             g2 = moments.Demes.DemesUtil.rescale(g, Q)
-            fs2 = moments.Demes.SFS(g2, samples=samples, u=u / Q)
+            fs2 = moments.Demes.SFS(g2, samples=samples, u=u * Q)
             self.assertTrue(np.allclose(fs, fs2))
 
     def test_rescaled_reversible_mutation(self):
@@ -2114,9 +2114,9 @@ class TestDemesRescaling(unittest.TestCase):
         fs = moments.Demes.SFS(g, samples=samples, u=u, reversible=True)
         fsb = moments.Demes.SFS(g, samples=samples, theta=theta, reversible=True)
 
-        for Q in [0.1, 0.5, 2]:
+        for Q in [10, 2, 0.5]:
             g2 = moments.Demes.DemesUtil.rescale(g, Q)
-            u_scaled = [u1 / Q, u2 / Q]
+            u_scaled = [u1 * Q, u2 * Q]
             fs2 = moments.Demes.SFS(g2, samples=samples, u=u_scaled, reversible=True)
             self.assertTrue(np.allclose(fs, fs2))
 


### PR DESCRIPTION
The rescaling parameter Q is commonly defined to divide population sizes, so that Q>1 implies a rescaled simulation with smaller population sizes and times. The DemesUtil function rescale() previously defined Q as the inverse. See #195. This is a breaking change that inverts our definition of Q to match standard conventions.