### PR TITLE
Remove import of scipy.misc

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,31 +15,6 @@ solving the diffusion system, removing the need for frequency grids as used in
 computing linkage disequilibrium statistics and running multi-population
 demographic inference using patterns of LD.
 
-If you use `moments` in your research, please cite:
-
-- Jouganous, J., Long, W., Ragsdale, A. P., & Gravel, S. (2017). Inferring the joint
-  demographic history of multiple populations: beyond the diffusion approximation.
-  Genetics, 206(3), 1549-1567.
-
-If you use `moments.LD` in your research, please cite:
-
-- Ragsdale, A. P. & Gravel, S. (2019). Models of archaic admixture and recent history
-  from two-locus statistics. PLoS Genetics, 15(6), e1008204.
-
-- Ragsdale, A. P. & Gravel, S. (2020). Unbiased estimation of linkage disequilibrium
-  from unphased data. Mol Biol Evol, 37(3), 923-932.
-
-If you use `moments.TwoLocus` in your research, please cite:
-
-- Ragsdale, A. P. (2021). Can we distinguish modes of selective interactions
-  from linkage disequilibrium? BioRxiv, doi: https://doi.org/10.1101/2021.03.25.437004
-
-`moments` is developed in the [Simon
-Gravel](http://simongravel.lab.mcgill.ca/Home.html) and [Aaron
-Ragsdale](https://apragsdale.github.io/) research groups, at McGill University and
-UW-Madison, respectively. For any issues, questions or bug reports, please open
-an [issue on Github](https://github.com/MomentsLD/moments/issues).
-
 ## Getting started
 
 `moments` now supports Python 3, and we no longer guarantee compatibility with
@@ -51,7 +26,9 @@ The simplest way to install `moments` is using `pip`:
 pip install moments-popgen
 ```
 
-`moments` can then be imported using `import moments`.
+`moments` can then be imported using `import moments`. <b>Important note:</b>
+`pip install moments` installs a different package named moments, and our
+pypi package is named `moments-popgen`.
 
 We can install the development branch directly from Github by running
 
@@ -79,6 +56,33 @@ If you use `conda`, `moments` is available via `bioconda`:
 conda config --add channels bioconda
 conda install moments
 ```
+
+## Citing moments
+
+If you use `moments` in your research, please cite:
+
+- Jouganous, J., Long, W., Ragsdale, A. P., & Gravel, S. (2017). Inferring the joint
+  demographic history of multiple populations: beyond the diffusion approximation.
+  Genetics, 206(3), 1549-1567.
+
+If you use `moments.LD` in your research, please cite:
+
+- Ragsdale, A. P. & Gravel, S. (2019). Models of archaic admixture and recent history
+  from two-locus statistics. PLoS Genetics, 15(6), e1008204.
+
+- Ragsdale, A. P. & Gravel, S. (2020). Unbiased estimation of linkage disequilibrium
+  from unphased data. Mol Biol Evol, 37(3), 923-932.
+
+If you use `moments.TwoLocus` in your research, please cite:
+
+- Ragsdale, A. P. (2021). Can we distinguish modes of selective interactions
+  from linkage disequilibrium? BioRxiv, doi: https://doi.org/10.1101/2021.03.25.437004
+
+`moments` is developed in the [Simon
+Gravel](http://simongravel.lab.mcgill.ca/Home.html) and [Aaron
+Ragsdale](https://apragsdale.github.io/) research groups, at McGill University and
+UW-Madison, respectively. For any issues, questions or bug reports, please open
+an [issue on Github](https://github.com/MomentsLD/moments/issues).
 
 ### Dependencies
 

--- a/moments/Manips.py
+++ b/moments/Manips.py
@@ -1,5 +1,4 @@
 import numpy as np
-import scipy.misc as misc
 import warnings
 
 from . import ModelPlot

--- a/moments/Numerics.py
+++ b/moments/Numerics.py
@@ -7,15 +7,6 @@ logger = logging.getLogger("Numerics")
 
 import functools, os
 import numpy
-
-# Account for difference in scipy installations.
-try:
-    from scipy.misc import comb
-except ImportError:
-    try:
-        from scipy.special import comb
-    except ImportError:
-        from scipy import comb
 from scipy.special import gammaln
 
 

--- a/moments/Spectrum_mod.py
+++ b/moments/Spectrum_mod.py
@@ -11,7 +11,6 @@ import os
 import sys
 import numpy as np
 from numpy import newaxis as nuax
-import scipy.misc as misc
 import scipy.stats
 import copy
 import itertools

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ authors = [
     {name = "Ryan Gutenkunst"},
 ]
 license = {text = "MIT"}
-requires-python = ">=3.8, <3.13"
+requires-python = ">=3.8, <3.14"
 dynamic = ["version"]
 dependencies=[
     "numpy >=1.12.1, <2.0",


### PR DESCRIPTION
Wheel building actions are failing due to a Deprecation warning (which is set to cause an error), stating, `DeprecationWarning: scipy.misc is deprecated and will be removed in 2.0.0`. It turns out we don't actually use `scipy.misc`, so this removes those imports.