### PR TITLE
Fix bug in varcov inv caching with mismatched sizes

### DIFF
--- a/moments/LD/Inference.py
+++ b/moments/LD/Inference.py
@@ -235,8 +235,10 @@ def ll_over_bins(xs, mus, Sigmas):
     for ii in range(len(xs)):
         # get var-cov inverse from cache dictionary, or compute it
         recompute = True
-        if ii in _varcov_inv_cache and np.all(
-            _varcov_inv_cache[ii]["data"] == Sigmas[ii]
+        if (
+            ii in _varcov_inv_cache
+            and (_varcov_inv_cache[ii]["data"].size == Sigmas[ii].size)
+            and np.all(_varcov_inv_cache[ii]["data"] == Sigmas[ii])
         ):
             Sigma_inv = _varcov_inv_cache[ii]["inv"]
             recompute = False


### PR DESCRIPTION
Results in error that isn't helpful to the user, and shouldn't raise an error anyway:
```
ValueError: operands could not be broadcast together with shapes (3,3) (2,2)
```