### PR TITLE
Fix bug in `Godambe.sum_chi2_ppf()`

### DIFF
--- a/moments/Godambe.py
+++ b/moments/Godambe.py
@@ -372,6 +372,8 @@ def sum_chi2_ppf(x, weights=(0, 1)):
     # scalar on output.
     if numpy.isscalar(x):
         scalar_input = True
+    else:
+        scalar_input = False
     # Convert x into an array, so we can index it easily.
     x = numpy.atleast_1d(x)
     # Calculate total cdf of all chi^2 dists with dof > 1.


### PR DESCRIPTION
As noted in #227, non-scalar inputs will cause an error. This fixes that.