### PR TITLE
Function to remove stat names of normalizing statistic

### DIFF
--- a/docs/api/api_demes.rst
+++ b/docs/api/api_demes.rst
@@ -11,6 +11,8 @@ Computing statistics from ``demes``
 
 .. autofunction:: moments.Demes.LD
 
+.. autofunction:: moments.Demes.LDdecay
+
 Running SFS inference using ``demes``
 -------------------------------------
 

--- a/moments/LD/Inference.py
+++ b/moments/LD/Inference.py
@@ -173,6 +173,37 @@ def remove_normalized_data(
         return ms, vcs, stats
 
 
+def remove_normalized_stat_name(statistics=None, normalization=0, num_pops=None):
+    """
+    Returns the set of statistic names with the normalizing statistic removed. Note that
+    the normalizing statistics for LD and H must be present for this function to not
+    fail.
+
+    If the list of statistics are not provided, set the number of populations so that
+    all statistics are present, aside from the removed normalizing statistic.
+
+    :param statistics: Tuple of lists, with length two, specifying the names of LD stats
+        and H stats. See ``moments.LD.Util.moment_names()``.
+    :param normalization: The index of the normalizing population.
+    :param num_pops: The number of populations to generate statistic names for. Cannot be
+        used with ``statistics``.
+    :return: Tuple of lists with statistic names, with normalizing statistics removed.
+    """
+    if statistics is None:
+        if num_pops is None:
+            raise ValueError(
+                "if `statistics` are not given, we must provide `num_pops`"
+            )
+        statistics = moments.LD.Util.moment_names(num_pops)
+    norm_ld = f"pi2_{normalization}_{normalization}_{normalization}_{normalization}"
+    norm_h = f"H_{normalization}_{normalization}"
+    stats_out_ld = copy.deepcopy(statistics[0])
+    stats_out_h = copy.deepcopy(statistics[1])
+    stats_out_ld.pop(stats_out_ld.index(norm_ld))
+    stats_out_h.pop(stats_out_h.index(norm_h))
+    return (stats_out_ld, stats_out_h)
+
+
 def remove_nonpresent_statistics(y, statistics=[[], []]):
     """
     Removes data not found in the given set of statistics.
@@ -209,6 +240,7 @@ def _ll(x, mu, Sigma_inv):
         return 0
     else:
         return -1.0 / 2 * np.dot(np.dot((x - mu).transpose(), Sigma_inv), x - mu)
+        ## NOTE: fix this to return actuall LL, should also be negative...
         # - len(x)*np.pi - 1./2*np.log(np.linalg.det(Sigma))
 
 

--- a/moments/Spectrum_mod.py
+++ b/moments/Spectrum_mod.py
@@ -717,7 +717,7 @@ class Spectrum(np.ma.masked_array):
             heterozygotes, in a selection system with fitnesses 1:1+s:1. Underdominance
             can be modeled by passing a negative value. Not that this is a symmetric
             under/over-dominance model, in which homozygotes for either the ancestral
-            or derived allele have equal fitness. `gamma`, `h`, and `overdominance`
+            or derived allele have equal fitness. ``gamma``, ``h``, and ``overdominance``
             can be combined (additively) to implement non-symmetric selection
             scenarios.
         :type overdominance: float or list of floats or function that returns a float or
@@ -725,7 +725,7 @@ class Spectrum(np.ma.masked_array):
         :param m: The migration rates matrix as a 2-D array with shape nxn,
             where n is the number of populations. The entry of the migration
             matrix m[i,j] is the migration rate from pop j to pop i in genetic
-            units, that is, normalized by :math:`2N_e`. `m` may be either a
+            units, that is, normalized by :math:`2N_e`. ``m`` may be either a
             2-D array, or a function that returns a 2-D array (with dimensions
             equal to (num pops)x(num pops)).
         :type m: array-like, optional
@@ -2093,7 +2093,7 @@ class Spectrum(np.ma.masked_array):
             Used to determine the haploid sample size from the number of sampled
             individuals when ``sample_sizes`` is not given.
         :type plody: int, optional
-        :param verbose: If > 0, print a progress message every `verbose` lines
+        :param verbose: If > 0, print a progress message every ``verbose`` lines
             (default 0).
         :type verbose: int, optional
         :param folded: If True, return the folded SFS (default False).
@@ -2148,7 +2148,7 @@ class Spectrum(np.ma.masked_array):
             quickly in the number of populations.
 
         :param g: A ``demes`` DemeGraph from which to compute the SFS. The DemeGraph
-            can either be specified as a YAML file, in which case `g` is a string,
+            can either be specified as a YAML file, in which case ``g`` is a string,
             or as a ``DemeGraph`` object.
         :type g: str or :class:`demes.DemeGraph`
         :param sampled_demes: A list of deme IDs to take samples from. We can repeat
@@ -2174,7 +2174,7 @@ class Spectrum(np.ma.masked_array):
             be given as a dictionary, with keys given as population names in the
             input Demes model. Any population missing from this dictionary will be
             assigned a selection coefficient of zero. A non-zero default selection
-            coefficient can be provided, using the key `_default`. See the Demes
+            coefficient can be provided, using the key ``_default``. See the Demes
             exension documentation for more details and examples.
         :type gamma: float or dict
         :param h: The dominance coefficient(s). Defaults to additivity (or genic
@@ -2183,13 +2183,13 @@ class Spectrum(np.ma.masked_array):
             dictionary, with keys given as population names in the input Demes model.
             Any population missing from this dictionary will be assigned a dominance
             coefficient of 1/2 (additivity). A different default dominance
-            coefficient can be provided, using the key `_default`. See the Demes
+            coefficient can be provided, using the key ``_default``. See the Demes
             exension documentation for more details and examples.
         :type h: float or dict
         :param theta: The population-size scaled mutation rate (4*Ne*u or 4*Ne*u*L).
             The default value is 1. For more control of mutation rates and mutation
             models (including using a reversible mutation model), please use
-            `moments.Demes.SFS`, which has options to specify theta, the per-base
+            ``moments.Demes.SFS``, which has options to specify theta, the per-base
             mutation rate u, and/or a reversible mutation model that allows for
             different forward and backward mutation rates.
         :type theta: scalar


### PR DESCRIPTION
It's clunky to keep track of statistics and statistic names in the LD methods, especially after removing normalizing stats. This adds a simple function to remove normalizing stat names from the lists of statistics, which can then be passed to inference and uncertainty calculation functions.